### PR TITLE
Bit operations: change types and implement

### DIFF
--- a/asl_xdsl/interpreters/asl.py
+++ b/asl_xdsl/interpreters/asl.py
@@ -13,6 +13,7 @@ from xdsl.interpreter import (
     register_impls,
 )
 from xdsl.ir import Operation
+from xdsl.utils.comparisons import to_signed, to_unsigned
 
 from asl_xdsl.dialects import asl
 
@@ -244,12 +245,171 @@ class ASLFunctions(InterpreterFunctions):
         (lhs, rhs) = args
         return (lhs > rhs,)
 
+    @impl(asl.AddBitsOp)
+    def run_add_bits(
+        self, interpreter: Interpreter, op: asl.AddBitsOp, args: tuple[Any, ...]
+    ) -> tuple[Any, ...]:
+        assert isinstance(op.lhs.type, asl.BitVectorType)
+        width = op.lhs.type.width.data
+        lhs: int
+        rhs: int
+        (lhs, rhs) = args
+        result = to_unsigned(lhs + rhs, width)
+        return (result,)
+
+    @impl(asl.SubBitsOp)
+    def run_sub_bits(
+        self, interpreter: Interpreter, op: asl.SubBitsOp, args: tuple[Any, ...]
+    ) -> tuple[Any, ...]:
+        assert isinstance(op.lhs.type, asl.BitVectorType)
+        width = op.lhs.type.width.data
+        lhs: int
+        rhs: int
+        (lhs, rhs) = args
+        result = to_unsigned(lhs - rhs, width)
+        return (result,)
+
+    @impl(asl.MulBitsOp)
+    def run_mul_bits(
+        self, interpreter: Interpreter, op: asl.MulBitsOp, args: tuple[Any, ...]
+    ) -> tuple[Any, ...]:
+        assert isinstance(op.lhs.type, asl.BitVectorType)
+        width = op.lhs.type.width.data
+        lhs: int
+        rhs: int
+        (lhs, rhs) = args
+        result = to_unsigned(lhs * rhs, width)
+        return (result,)
+
+    @impl(asl.AndBitsOp)
+    def run_and_bits(
+        self, interpreter: Interpreter, op: asl.AndBitsOp, args: tuple[Any, ...]
+    ) -> tuple[Any, ...]:
+        lhs: int
+        rhs: int
+        (lhs, rhs) = args
+        return (lhs & rhs,)
+
+    @impl(asl.OrBitsOp)
+    def run_or_bits(
+        self, interpreter: Interpreter, op: asl.OrBitsOp, args: tuple[Any, ...]
+    ) -> tuple[Any, ...]:
+        lhs: int
+        rhs: int
+        (lhs, rhs) = args
+        return (lhs | rhs,)
+
+    @impl(asl.XorBitsOp)
+    def run_xor_bits(
+        self, interpreter: Interpreter, op: asl.XorBitsOp, args: tuple[Any, ...]
+    ) -> tuple[Any, ...]:
+        lhs: int
+        rhs: int
+        (lhs, rhs) = args
+        return (lhs ^ rhs,)
+
+    @impl(asl.LslBitsOp)
+    def run_lsl_bits(
+        self, interpreter: Interpreter, op: asl.LslBitsOp, args: tuple[Any, ...]
+    ) -> tuple[Any, ...]:
+        assert isinstance(op.lhs.type, asl.BitVectorType)
+        width = op.lhs.type.width.data
+        lhs: int
+        rhs: int
+        (lhs, rhs) = args
+        result = to_unsigned(lhs << rhs, width)
+        return (result,)
+
+    @impl(asl.LsrBitsOp)
+    def run_lsr_bits(
+        self, interpreter: Interpreter, op: asl.LsrBitsOp, args: tuple[Any, ...]
+    ) -> tuple[Any, ...]:
+        assert isinstance(op.lhs.type, asl.BitVectorType)
+        width = op.lhs.type.width.data
+        lhs: int
+        rhs: int
+        (lhs, rhs) = args
+        result = to_unsigned(lhs >> rhs, width)
+        return (result,)
+
+    @impl(asl.AsrBitsOp)
+    def run_asr_bits(
+        self, interpreter: Interpreter, op: asl.AsrBitsOp, args: tuple[Any, ...]
+    ) -> tuple[Any, ...]:
+        assert isinstance(op.lhs.type, asl.BitVectorType)
+        width = op.lhs.type.width.data
+        lhs: int
+        rhs: int
+        (lhs, rhs) = args
+        if lhs >= 2 ** (width - 1):
+            lhs = lhs - 2**width
+        result = to_unsigned(lhs >> rhs, width)
+        return (result,)
+
+    @impl(asl.NotBitsOp)
+    def run_not_bits(
+        self, interpreter: Interpreter, op: asl.NotBitsOp, args: tuple[Any, ...]
+    ) -> tuple[Any, ...]:
+        assert isinstance(op.arg.type, asl.BitVectorType)
+        width = op.arg.type.width.data
+        arg: int
+        [arg] = args
+        result = (1 << width) - 1 - arg
+        return (result,)
+
+    @impl(asl.CvtBitsUIntOp)
+    def run_cvt_bits_uint_bits(
+        self, interpreter: Interpreter, op: asl.CvtBitsUIntOp, args: tuple[Any, ...]
+    ) -> tuple[Any, ...]:
+        assert isinstance(op.arg.type, asl.BitVectorType)
+        width = op.arg.type.width.data
+        arg: int
+        [arg] = args
+        result = to_unsigned(arg, width)
+        return (result,)
+
+    @impl(asl.CvtBitsSIntOp)
+    def run_cvt_bits_sint_bits(
+        self, interpreter: Interpreter, op: asl.CvtBitsSIntOp, args: tuple[Any, ...]
+    ) -> tuple[Any, ...]:
+        assert isinstance(op.arg.type, asl.BitVectorType)
+        width = op.arg.type.width.data
+        arg: int
+        [arg] = args
+        result = to_signed(arg, width)
+        return (result,)
+
+    @impl(asl.EqBitsOp)
+    def run_eq_bits(
+        self, interpreter: Interpreter, op: asl.EqBitsOp, args: tuple[Any, ...]
+    ) -> tuple[Any, ...]:
+        lhs: int
+        rhs: int
+        (lhs, rhs) = args
+        return (lhs == rhs,)
+
+    @impl(asl.NeBitsOp)
+    def run_ne_bits(
+        self, interpreter: Interpreter, op: asl.NeBitsOp, args: tuple[Any, ...]
+    ) -> tuple[Any, ...]:
+        lhs: int
+        rhs: int
+        (lhs, rhs) = args
+        return (lhs != rhs,)
+
     @impl(asl.ConstantIntOp)
     def run_constant_int(
         self, interpreter: Interpreter, op: asl.ConstantIntOp, args: PythonValues
     ) -> PythonValues:
         value = op.value
         return (value.data,)
+
+    @impl(asl.ConstantBitVectorOp)
+    def run_constant_bits(
+        self, interpreter: Interpreter, op: asl.ConstantBitVectorOp, args: PythonValues
+    ) -> PythonValues:
+        value = op.value
+        return (value.value.data,)
 
     @impl(asl.ConstantStringOp)
     def run_constant_string(
@@ -258,16 +418,19 @@ class ASLFunctions(InterpreterFunctions):
         value = op.value
         return (value.data,)
 
-    # region built-in function implementations
-
-    @impl_external("print_bits_hex.0")
+    @impl(asl.PrintBitsHexOp)
     def asl_print_bits_hex(
-        self, interpreter: Interpreter, op: Operation, args: PythonValues
+        self, interpreter: Interpreter, op: asl.PrintBitsHexOp, args: PythonValues
     ) -> PythonValues:
+        assert isinstance(op.arg.type, asl.BitVectorType)
+        width = op.arg.type.width.data
         arg: int
         (arg,) = args
-        interpreter.print(hex(arg))
+        output = f"{width:d}'x{arg:x}"
+        interpreter.print(output)
         return ()
+
+    # region built-in function implementations
 
     @impl_external("print_int_dec.0")
     def asl_print_int_dec(

--- a/tests/filecheck/dialects/asl/primitives.mlir
+++ b/tests/filecheck/dialects/asl/primitives.mlir
@@ -54,14 +54,33 @@ builtin.module {
 
     %bits1, %bits2 = "test.op"() : () -> (!asl.bits<32>, !asl.bits<32>)
 
-    %add_bits = asl.add_bits %bits1, %bits2 : !asl.bits<32>
-    %add_bits_int = asl.add_bits_int %bits1, %int1 : !asl.bits<32>
-    %sub_bits = asl.sub_bits %bits1, %bits2 : !asl.bits<32>
-    %sub_bits_int = asl.sub_bits_int %bits1, %int1 : !asl.bits<32>
-    %not_bits = asl.not_bits %bits1 : !asl.bits<32>
-    %and_bits = asl.and_bits %bits1, %bits2 : !asl.bits<32>
-    %or_bits = asl.or_bits %bits1, %bits2 : !asl.bits<32>
-    %xor_bits = asl.xor_bits %bits1, %bits2 : !asl.bits<32>
-    %eq_bits = asl.eq_bits %bits1, %bits2 : !asl.bits<32>
-    %ne_bits = asl.ne_bits %bits1, %bits2 : !asl.bits<32>
+    %add_bits = asl.add_bits %bits1, %bits2 : (!asl.bits<32>, !asl.bits<32>) -> !asl.bits<32>
+    %add_bits_int = asl.add_bits_int %bits1, %int1 : (!asl.bits<32>, !asl.int) -> !asl.bits<32>
+    %sub_bits = asl.sub_bits %bits1, %bits2 : (!asl.bits<32>, !asl.bits<32>) -> !asl.bits<32>
+    %sub_bits_int = asl.sub_bits_int %bits1, %int1 : (!asl.bits<32>, !asl.int) -> !asl.bits<32>
+    %mul_bits = asl.mul_bits %bits1, %bits2 : (!asl.bits<32>, !asl.bits<32>) -> !asl.bits<32>
+    %not_bits = asl.not_bits %bits1 : !asl.bits<32> -> !asl.bits<32>
+    %sint_bits = asl.cvt_bits_sint %bits1 : !asl.bits<32> -> !asl.int
+    %uint_bits = asl.cvt_bits_uint %bits1 : !asl.bits<32> -> !asl.int
+    %and_bits = asl.and_bits %bits1, %bits2 : (!asl.bits<32>, !asl.bits<32>) -> !asl.bits<32>
+    %or_bits = asl.or_bits %bits1, %bits2 : (!asl.bits<32>, !asl.bits<32>) -> !asl.bits<32>
+    %xor_bits = asl.xor_bits %bits1, %bits2 : (!asl.bits<32>, !asl.bits<32>) -> !asl.bits<32>
+    %eq_bits = asl.eq_bits %bits1, %bits2 : (!asl.bits<32>, !asl.bits<32>) -> i1
+    %ne_bits = asl.ne_bits %bits1, %bits2 : (!asl.bits<32>, !asl.bits<32>) -> i1
+    asl.print_bits_hex %bits1 : !asl.bits<32> -> ()
+
+// CHECK:         %add_bits = asl.add_bits %bits1, %bits2 : (!asl.bits<32>, !asl.bits<32>) -> !asl.bits<32>
+// CHECK-NEXT:    %add_bits_int = asl.add_bits_int %bits1, %int1 : (!asl.bits<32>, !asl.int) -> !asl.bits<32>
+// CHECK-NEXT:    %sub_bits = asl.sub_bits %bits1, %bits2 : (!asl.bits<32>, !asl.bits<32>) -> !asl.bits<32>
+// CHECK-NEXT:    %sub_bits_int = asl.sub_bits_int %bits1, %int1 : (!asl.bits<32>, !asl.int) -> !asl.bits<32>
+// CHECK-NEXT:    %mul_bits = asl.mul_bits %bits1, %bits2 : (!asl.bits<32>, !asl.bits<32>) -> !asl.bits<32>
+// CHECK-NEXT:    %not_bits = asl.not_bits %bits1 : !asl.bits<32> -> !asl.bits<32>
+// CHECK-NEXT:    %sint_bits = asl.cvt_bits_sint %bits1 : !asl.bits<32> -> !asl.int
+// CHECK-NEXT:    %uint_bits = asl.cvt_bits_uint %bits1 : !asl.bits<32> -> !asl.int
+// CHECK-NEXT:    %and_bits = asl.and_bits %bits1, %bits2 : (!asl.bits<32>, !asl.bits<32>) -> !asl.bits<32>
+// CHECK-NEXT:    %or_bits = asl.or_bits %bits1, %bits2 : (!asl.bits<32>, !asl.bits<32>) -> !asl.bits<32>
+// CHECK-NEXT:    %xor_bits = asl.xor_bits %bits1, %bits2 : (!asl.bits<32>, !asl.bits<32>) -> !asl.bits<32>
+// CHECK-NEXT:    %eq_bits = asl.eq_bits %bits1, %bits2 : (!asl.bits<32>, !asl.bits<32>) -> i1
+// CHECK-NEXT:    %ne_bits = asl.ne_bits %bits1, %bits2 : (!asl.bits<32>, !asl.bits<32>) -> i1
+// CHECK-NEXT:    asl.print_bits_hex %bits1 : !asl.bits<32> -> ()
 }


### PR DESCRIPTION
This changes the way that types are printed to be consistent with the integer operations:

    asl.foo %0, %1 : (!asl.bits<4>, !asl.bits<4>) -> !asl.bits<4>

And it adds a bunch more operations and implements them