### PR TITLE
Remaining bit operations

### DIFF
--- a/asl_xdsl/dialects/asl.py
+++ b/asl_xdsl/dialects/asl.py
@@ -828,6 +828,217 @@ class AsrBitsOp(IRDLOperation):
 
 
 @irdl_op_definition
+class ZeroExtendBitsOp(IRDLOperation):
+    """A bit vector zero-extend operation."""
+
+    name = "asl.zero_extend_bits"
+
+    S: ClassVar = VarConstraint("S", BaseAttr(BitVectorType))
+    T: ClassVar = VarConstraint("T", BaseAttr(BitVectorType))
+
+    lhs = operand_def(S)
+    rhs = operand_def(IntegerType())
+    res = result_def(T)
+
+    assembly_format = (
+        "$lhs `,` $rhs `:` `(` type($lhs) `,` type($rhs) `)` `->` type($res) attr-dict"
+    )
+
+    def __init__(
+        self,
+        lhs: SSAValue,
+        rhs: SSAValue,
+        res: SSAValue,
+        attr_dict: Mapping[str, Attribute] = {},
+    ):
+        super().__init__(
+            operands=[lhs, rhs],
+            result_types=[res.type],
+            attributes=attr_dict,
+        )
+
+
+@irdl_op_definition
+class SignExtendBitsOp(IRDLOperation):
+    """A bit vector zero-extend operation."""
+
+    name = "asl.sign_extend_bits"
+
+    S: ClassVar = VarConstraint("S", BaseAttr(BitVectorType))
+    T: ClassVar = VarConstraint("T", BaseAttr(BitVectorType))
+
+    lhs = operand_def(S)
+    rhs = operand_def(IntegerType())
+    res = result_def(T)
+
+    assembly_format = (
+        "$lhs `,` $rhs `:` `(` type($lhs) `,` type($rhs) `)` `->` type($res) attr-dict"
+    )
+
+    def __init__(
+        self,
+        lhs: SSAValue,
+        rhs: SSAValue,
+        res: SSAValue,
+        attr_dict: Mapping[str, Attribute] = {},
+    ):
+        super().__init__(
+            operands=[lhs, rhs],
+            result_types=[res.type],
+            attributes=attr_dict,
+        )
+
+
+@irdl_op_definition
+class AppendBitsOp(IRDLOperation):
+    """A bit vector append operation."""
+
+    name = "asl.append_bits"
+
+    S: ClassVar = VarConstraint("S", BaseAttr(BitVectorType))
+    T: ClassVar = VarConstraint("T", BaseAttr(BitVectorType))
+    U: ClassVar = VarConstraint("U", BaseAttr(BitVectorType))
+
+    lhs = operand_def(S)
+    rhs = operand_def(T)
+    res = result_def(U)
+
+    assembly_format = (
+        "$lhs `,` $rhs `:` `(` type($lhs) `,` type($rhs) `)` `->` type($res) attr-dict"
+    )
+
+    def __init__(
+        self,
+        lhs: SSAValue,
+        rhs: SSAValue,
+        res: SSAValue,
+        attr_dict: Mapping[str, Attribute] = {},
+    ):
+        super().__init__(
+            operands=[lhs, rhs],
+            result_types=[res.type],
+            attributes=attr_dict,
+        )
+
+
+@irdl_op_definition
+class ReplicateBitsOp(IRDLOperation):
+    """A bit vector replication operation."""
+
+    name = "asl.replicate_bits"
+
+    S: ClassVar = VarConstraint("S", BaseAttr(BitVectorType))
+    T: ClassVar = VarConstraint("T", BaseAttr(BitVectorType))
+
+    lhs = operand_def(S)
+    rhs = operand_def(IntegerType())
+    res = result_def(T)
+
+    assembly_format = (
+        "$lhs `,` $rhs `:` `(` type($lhs) `,` type($rhs) `)` `->` type($res) attr-dict"
+    )
+
+    def __init__(
+        self,
+        lhs: SSAValue,
+        rhs: SSAValue,
+        res: SSAValue,
+        attr_dict: Mapping[str, Attribute] = {},
+    ):
+        super().__init__(
+            operands=[lhs, rhs],
+            result_types=[res.type],
+            attributes=attr_dict,
+        )
+
+
+@irdl_op_definition
+class ZerosBitsOp(IRDLOperation):
+    """A bit vector all-zeros operation."""
+
+    name = "asl.zeros_bits"
+
+    T: ClassVar = VarConstraint("T", BaseAttr(BitVectorType))
+
+    arg = operand_def(IntegerType())
+    res = result_def(T)
+
+    assembly_format = "$arg `:` type($arg) `->` type($res) attr-dict"
+
+    def __init__(
+        self,
+        arg: SSAValue,
+        res: SSAValue,
+        attr_dict: Mapping[str, Attribute] = {},
+    ):
+        super().__init__(
+            operands=[arg],
+            result_types=[res.type],
+            attributes=attr_dict,
+        )
+
+
+@irdl_op_definition
+class OnesBitsOp(IRDLOperation):
+    """A bit vector all-ones operation."""
+
+    name = "asl.ones_bits"
+
+    T: ClassVar = VarConstraint("T", BaseAttr(BitVectorType))
+
+    arg = operand_def(IntegerType())
+    res = result_def(T)
+
+    assembly_format = "$arg `:` type($arg) `->` type($res) attr-dict"
+
+    def __init__(
+        self,
+        arg: SSAValue,
+        res: SSAValue,
+        attr_dict: Mapping[str, Attribute] = {},
+    ):
+        super().__init__(
+            operands=[arg],
+            result_types=[res.type],
+            attributes=attr_dict,
+        )
+
+
+@irdl_op_definition
+class MkMaskBitsOp(IRDLOperation):
+    """
+    A bit vector mask generation operation.
+    `mk_mask(x, N) : bits(N)` consists of `x` ones.
+    For example, `mk_mask(3, 8) == '0000 0111'`.
+    """
+
+    name = "asl.mk_mask"
+
+    T: ClassVar = VarConstraint("T", BaseAttr(BitVectorType))
+
+    lhs = operand_def(IntegerType())
+    rhs = operand_def(IntegerType())
+    res = result_def(T)
+
+    assembly_format = (
+        "$lhs `,` $rhs `:` `(` type($lhs) `,` type($rhs) `)` `->` type($res) attr-dict"
+    )
+
+    def __init__(
+        self,
+        lhs: SSAValue,
+        rhs: SSAValue,
+        res: SSAValue,
+        attr_dict: Mapping[str, Attribute] = {},
+    ):
+        super().__init__(
+            operands=[lhs, rhs],
+            result_types=[res.type],
+            attributes=attr_dict,
+        )
+
+
+@irdl_op_definition
 class NotBitsOp(IRDLOperation):
     """A bitwise NOT operation."""
 
@@ -1166,28 +1377,70 @@ class CallOp(IRDLOperation):
 
 
 @irdl_op_definition
-class SliceSingleOp(IRDLOperation):
-    """Slice a single element from a bit vector."""
+class GetSliceOp(IRDLOperation):
+    """Extract a slice from a bit vector."""
 
-    name = "asl.slice_single"
+    name = "asl.get_slice"
 
-    bits = operand_def(BitVectorType)
+    S: ClassVar = VarConstraint("S", BaseAttr(BitVectorType))
+    T: ClassVar = VarConstraint("T", BaseAttr(BitVectorType))
+
+    bits = operand_def(S)
     index = operand_def(IntegerType)
+    width = operand_def(IntegerType)
 
-    res = result_def(BitVectorType(1))
+    res = result_def(T)
 
     assembly_format = (
-        "$bits `[` $index `]` `:` type($bits) `[` type($index) `]` attr-dict"
+        "$bits `,` $index `,` $width "
+        "`:` `(` type($bits) `,` type($index) `,` type($width) `)` "
+        "`->` type($res) attr-dict"
     )
 
     def __init__(
         self,
         bits: SSAValue,
         index: SSAValue,
+        width: SSAValue,
+        res: SSAValue,
     ):
         super().__init__(
-            operands=[bits, index],
-            result_types=[BitVectorType(1)],
+            operands=[bits, index, width],
+            result_types=[res.type],
+        )
+
+
+@irdl_op_definition
+class SetSliceOp(IRDLOperation):
+    """Insert a slice into a bit vector."""
+
+    name = "asl.set_slice"
+
+    S: ClassVar = VarConstraint("S", BaseAttr(BitVectorType))
+    T: ClassVar = VarConstraint("T", BaseAttr(BitVectorType))
+
+    bits = operand_def(S)
+    index = operand_def(IntegerType)
+    width = operand_def(IntegerType)
+    rhs = operand_def(T)
+    res = result_def(S)
+
+    assembly_format = (
+        "$bits `,` $index `,` $width `,` $rhs "
+        "`:` `(` type($bits) `,` type($index) `,` type($width) `,` type($rhs) `)` "
+        "`->` type($res) attr-dict"
+    )
+
+    def __init__(
+        self,
+        bits: SSAValue,
+        index: SSAValue,
+        width: SSAValue,
+        rhs: SSAValue,
+    ):
+        super().__init__(
+            operands=[bits, index, width, rhs],
+            result_types=[bits.type],
         )
 
 
@@ -1231,6 +1484,13 @@ ASLDialect = Dialect(
         LslBitsOp,
         LsrBitsOp,
         AsrBitsOp,
+        ZeroExtendBitsOp,
+        SignExtendBitsOp,
+        AppendBitsOp,
+        ReplicateBitsOp,
+        ZerosBitsOp,
+        OnesBitsOp,
+        MkMaskBitsOp,
         AddBitsIntOp,
         SubBitsIntOp,
         NotBitsOp,
@@ -1244,7 +1504,8 @@ ASLDialect = Dialect(
         FuncOp,
         CallOp,
         # Slices
-        SliceSingleOp,
+        GetSliceOp,
+        SetSliceOp,
     ],
     [
         IntegerType,

--- a/tests/filecheck/dialects/asl/primitives.mlir
+++ b/tests/filecheck/dialects/asl/primitives.mlir
@@ -53,12 +53,25 @@ builtin.module {
 // CHECK-NEXT:    %gt_int = asl.gt_int %int1, %int2
 
     %bits1, %bits2 = "test.op"() : () -> (!asl.bits<32>, !asl.bits<32>)
+    %zero = asl.constant_int 4 {attr_dict}
+    %four = asl.constant_int 4 {attr_dict}
+    %sf = asl.constant_int 64 {attr_dict}
 
     %add_bits = asl.add_bits %bits1, %bits2 : (!asl.bits<32>, !asl.bits<32>) -> !asl.bits<32>
     %add_bits_int = asl.add_bits_int %bits1, %int1 : (!asl.bits<32>, !asl.int) -> !asl.bits<32>
     %sub_bits = asl.sub_bits %bits1, %bits2 : (!asl.bits<32>, !asl.bits<32>) -> !asl.bits<32>
     %sub_bits_int = asl.sub_bits_int %bits1, %int1 : (!asl.bits<32>, !asl.int) -> !asl.bits<32>
     %mul_bits = asl.mul_bits %bits1, %bits2 : (!asl.bits<32>, !asl.bits<32>) -> !asl.bits<32>
+    %lsl_bits = asl.lsl_bits %bits1, %int1 : (!asl.bits<32>, !asl.int) -> !asl.bits<32>
+    %lsr_bits = asl.lsr_bits %bits1, %int1 : (!asl.bits<32>, !asl.int) -> !asl.bits<32>
+    %asr_bits = asl.asr_bits %bits1, %int1 : (!asl.bits<32>, !asl.int) -> !asl.bits<32>
+    %zext_bits = asl.zero_extend_bits %bits1, %sf : (!asl.bits<32>, !asl.int) -> !asl.bits<64>
+    %sext_bits = asl.sign_extend_bits %bits1, %sf : (!asl.bits<32>, !asl.int) -> !asl.bits<64>
+    %append_bits = asl.append_bits %bits1, %bits2 : (!asl.bits<32>, !asl.bits<32>) -> !asl.bits<64>
+    %replicate_bits = asl.replicate_bits %bits1, %four : (!asl.bits<32>, !asl.int) -> !asl.bits<128>
+    %zeros_bits = asl.zeros_bits %int1 : !asl.int -> !asl.bits<32>
+    %ones_bits = asl.ones_bits %int1 : !asl.int -> !asl.bits<32>
+    %mask_bits = asl.mk_mask %int1, %sf : (!asl.int, !asl.int) -> !asl.bits<64>
     %not_bits = asl.not_bits %bits1 : !asl.bits<32> -> !asl.bits<32>
     %sint_bits = asl.cvt_bits_sint %bits1 : !asl.bits<32> -> !asl.int
     %uint_bits = asl.cvt_bits_uint %bits1 : !asl.bits<32> -> !asl.int
@@ -68,12 +81,24 @@ builtin.module {
     %eq_bits = asl.eq_bits %bits1, %bits2 : (!asl.bits<32>, !asl.bits<32>) -> i1
     %ne_bits = asl.ne_bits %bits1, %bits2 : (!asl.bits<32>, !asl.bits<32>) -> i1
     asl.print_bits_hex %bits1 : !asl.bits<32> -> ()
+    %slice = asl.get_slice %bits1, %four, %four : (!asl.bits<32>, !asl.int, !asl.int) -> !asl.bits<4>
+    %set_slice = asl.set_slice %bits1, %zero, %four, %slice : (!asl.bits<32>, !asl.int, !asl.int, !asl.bits<4>) -> !asl.bits<32>
 
 // CHECK:         %add_bits = asl.add_bits %bits1, %bits2 : (!asl.bits<32>, !asl.bits<32>) -> !asl.bits<32>
 // CHECK-NEXT:    %add_bits_int = asl.add_bits_int %bits1, %int1 : (!asl.bits<32>, !asl.int) -> !asl.bits<32>
 // CHECK-NEXT:    %sub_bits = asl.sub_bits %bits1, %bits2 : (!asl.bits<32>, !asl.bits<32>) -> !asl.bits<32>
 // CHECK-NEXT:    %sub_bits_int = asl.sub_bits_int %bits1, %int1 : (!asl.bits<32>, !asl.int) -> !asl.bits<32>
 // CHECK-NEXT:    %mul_bits = asl.mul_bits %bits1, %bits2 : (!asl.bits<32>, !asl.bits<32>) -> !asl.bits<32>
+// CHECK-NEXT:    %lsl_bits = asl.lsl_bits %bits1, %int1 : (!asl.bits<32>, !asl.int) -> !asl.bits<32>
+// CHECK-NEXT:    %lsr_bits = asl.lsr_bits %bits1, %int1 : (!asl.bits<32>, !asl.int) -> !asl.bits<32>
+// CHECK-NEXT:    %asr_bits = asl.asr_bits %bits1, %int1 : (!asl.bits<32>, !asl.int) -> !asl.bits<32>
+// CHECK-NEXT:    %zext_bits = asl.zero_extend_bits %bits1, %sf : (!asl.bits<32>, !asl.int) -> !asl.bits<64>
+// CHECK-NEXT:    %sext_bits = asl.sign_extend_bits %bits1, %sf : (!asl.bits<32>, !asl.int) -> !asl.bits<64>
+// CHECK-NEXT:    %append_bits = asl.append_bits %bits1, %bits2 : (!asl.bits<32>, !asl.bits<32>) -> !asl.bits<64>
+// CHECK-NEXT:    %replicate_bits = asl.replicate_bits %bits1, %four : (!asl.bits<32>, !asl.int) -> !asl.bits<128>
+// CHECK-NEXT:    %zeros_bits = asl.zeros_bits %int1 : !asl.int -> !asl.bits<32>
+// CHECK-NEXT:    %ones_bits = asl.ones_bits %int1 : !asl.int -> !asl.bits<32>
+// CHECK-NEXT:    %mask_bits = asl.mk_mask %int1, %sf : (!asl.int, !asl.int) -> !asl.bits<64>
 // CHECK-NEXT:    %not_bits = asl.not_bits %bits1 : !asl.bits<32> -> !asl.bits<32>
 // CHECK-NEXT:    %sint_bits = asl.cvt_bits_sint %bits1 : !asl.bits<32> -> !asl.int
 // CHECK-NEXT:    %uint_bits = asl.cvt_bits_uint %bits1 : !asl.bits<32> -> !asl.int
@@ -83,4 +108,5 @@ builtin.module {
 // CHECK-NEXT:    %eq_bits = asl.eq_bits %bits1, %bits2 : (!asl.bits<32>, !asl.bits<32>) -> i1
 // CHECK-NEXT:    %ne_bits = asl.ne_bits %bits1, %bits2 : (!asl.bits<32>, !asl.bits<32>) -> i1
 // CHECK-NEXT:    asl.print_bits_hex %bits1 : !asl.bits<32> -> ()
+// CHECK-NEXT:    %slice = asl.get_slice %bits1, %four, %four : (!asl.bits<32>, !asl.int, !asl.int) -> !asl.bits<4>
 }

--- a/tests/filecheck/dialects/asl/slices.mlir
+++ b/tests/filecheck/dialects/asl/slices.mlir
@@ -1,7 +1,0 @@
-// RUN: asl-opt %s | asl-opt %s | filecheck %s
-
-builtin.module {
-    %bits, %index = "test.op"() : () -> (!asl.bits<42>, !asl.int)
-    asl.slice_single %bits[%index] : !asl.bits<42>[!asl.int]
-    // CHECK: asl.slice_single %bits[%index] : !asl.bits<42>
-}


### PR DESCRIPTION
Note that several of these operations have result types that require calculations based on the input values/types. For example

    func Replicate(x : bits(M), y : bits(N)) -> bits(M+N)

I don't know how to capture that dependency yet so I generalized the types like this

    func Replicate(x : bits(M), y : bits(N)) -> bits(O)
                                                ^^^^^^^

This lets me continue without getting blocked on how we will represent dependent types